### PR TITLE
Shadow Receiver URP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AR Foundation Samples
+# AR Foundation Samples 
 
 Example AR scenes that use [AR Foundation 6.0](https://docs.unity3d.com/Packages/com.unity.xr.arfoundation@6.0/manual/index.html) and demonstrate its features. Each feature is used in a minimal sample scene with example code that you can modify or copy into your project.
 


### PR DESCRIPTION
Hey there,

I came across this repo. Here you use the paid asset Shadow Receiver URP.
While I enjoy seeing my assets used in projects, I cannot allow the distribution of the assets for free on GitHub. This breaches the Unity Asset Store License as well.

Please remove the assets from the repository. If this is not possible we can discuss a custom license that allows you to use the assets in an open source project.

I would like to resolve this personally, without any takedowns via GitHub or the Unity Asset Store. I could not open an issue, so did it via a PR. Of course you can remove this PR after you fixed the issue.

Kind regards,
Dylan Smit